### PR TITLE
fix: add certification keyword to title occurrences

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Back End Development and APIs",
+  "name": "Back End Development and APIs Certification",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:4-24",
   "remoteUser": "node",
   "workspaceFolder": "/workspaces/back-end-development-and-apis",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Back End Development and APIs
+# Back End Development and APIs Certification
 
 This curriculum teaches you how to build back end applications and APIs using Node.js and Express. You will work through guided lessons that introduce new concepts step by step, then apply what you have learnt in independent practice projects.
 

--- a/freecodecamp.conf.json
+++ b/freecodecamp.conf.json
@@ -5,7 +5,7 @@
     "assets": null,
     "landing": {
       "english": {
-        "title": "Back End Development and APIs",
+        "title": "Back End Development and APIs Certification",
         "description": "In the Back End Development and APIs Certification, you'll learn how to write back end apps with Node.js and npm. You'll also build web applications with the Express framework, and build a microservice with MongoDB.",
         "faq-link": null,
         "faq-text": null


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

I saw Jessica mentioned we call it "Back End Development and APIs" instead of "Back End Development and APIs Certification"