### PR TITLE
fix(curriculum): correct content-type header check in Build a Personal Profile App

### DIFF
--- a/curriculum/locales/english/build-a-personal-profile-app.md
+++ b/curriculum/locales/english/build-a-personal-profile-app.md
@@ -76,7 +76,7 @@ The `/api/profile` route should return a JSON response with the correct content 
 ```js
 const response = await fetch(`${__url}api/profile`);
 const headers = response.headers;
-assert.include(headers["content-type"], "application/json");
+assert.include(headers.get("content-type"), "application/json");
 ```
 
 The `/api/profile` route should return a JSON object with a `name` property set to `Camper Bot`.


### PR DESCRIPTION
The test for the /api/profile content-type used bracket notation (headers["content-type"]) to access the Fetch API's Headers object, which always returns undefined since Headers requires .get(). This caused the test to fail with an AssertionError regardless of whether the server correctly set the content-type header.

Fixes the assertion by using headers.get("content-type") instead.

Checklist:
<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Closes #19