### PR TITLE
fix(tooling): handle BlockStatement in extractBody

### DIFF
--- a/tooling/helpers.js
+++ b/tooling/helpers.js
@@ -553,6 +553,8 @@ export class Tower {
         }
 
         throw new Error(`Unimplemented for ${ast.type}`);
+      case "BlockStatement":
+        return ast.body;
       default:
         throw new Error(`Unimplemented for ${ast.type}`);
     }


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

I ran into a problem with Step 35 of Build a Web Server. My code looked correct, so I checked the test — and then pasted in the seed from Step 36, which is the intended solution to Step 35. That failed too.

The cause is in tooling/helpers.js. The test does new Tower(errorIf.consequent), and for any braced if the consequent is a BlockStatement. extractBody has no case for it, so getCalls throws Unimplemented for BlockStatement before the assertion runs. There's no way to write the step that passes.

Adding a BlockStatement case fixes it.